### PR TITLE
Fix authorization renewal

### DIFF
--- a/lib/Account.js
+++ b/lib/Account.js
@@ -317,7 +317,7 @@ Account.prototype.renewAuthorization = function(callback) {
     data: {}
   };
 
-  if (!self.clientId || self.clientSecret) {
+  if (!self.clientId || !self.clientSecret) {
     Request.get('https://data-mind-687.appspot.com/clouddrive?refresh_token=' + self.token.refresh_token, function(err, response, body) {
       if (err) {
         return callback(err);


### PR DESCRIPTION
A little typo causes renewal to fail due to an error like the following:

``` json
{
    "success": true,
    "data": {
        "error_description": "Not authorized for requested operation",
        "error": "unauthorized_client",
        "last_authorized": 1449250363993
    }
}
```

This fixes it, plain and simple.
