### PR TITLE
Converting from `commander` to `yargs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All Notable changes to `clouddrive-node` will be documented in this file
 - `cat` command outputs contents of remote file to STDOUT.
 - Added "searching" spinner when running `find` command.
 - Refactored the entire codebase to use several ES6 features including classes, template strings, arrow function notations, etc.
+- Failed uploads due to expired tokens now retry `x` number of times (set in the config).
 
 ### Fixed
 - `download` command no longer outputs multiple "failure" messages when it fails to download remote file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ All Notable changes to `clouddrive-node` will be documented in this file
 - Added "searching" spinner when running `find` command.
 - Refactored the entire codebase to use several ES6 features including classes, template strings, arrow function notations, etc.
 - Failed uploads due to expired tokens now retry `x` number of times (set in the config).
+- Converted base CLI framework from `commander` to `yargs`.
 
 ### Fixed
 - `download` command no longer outputs multiple "failure" messages when it fails to download remote file.
 - Fixed authorization renewal issue where we weren't properly checking of the API key OR secret were both invalid.
 - Fixed exception when attempting to upload to `root` without any notation (empty path).
+- Fixed bug where we were not properly reading boolean values from the saved config.
 
 ## 0.2.2
 

--- a/bin/clouddrive.js
+++ b/bin/clouddrive.js
@@ -1,206 +1,377 @@
 #!/usr/bin/env node
-
 'use strict';
 
-var program = require('commander');
-var Command = require('../lib/Commands/Command');
+var yargs = require('yargs'),
+  colors = require('colors'),
+  Command = require('../lib/Commands/Command'),
+  semver = require('semver'),
+  pkgJson = require('../package.json');
 
-program.version('0.2.2');
+try {
+  if (semver.lt(process.version.replace('v', ''), '0.10.0')) {
+    console.error(`${pkgJson.name.cyan.bold}, CLI version ${pkgJson.version}`);
+    Command.error('ERROR: Cloud Drive requires Node.js 0.10 or newer.');
+    Command.log(`\nVisit ${'http://nodejs.org/'.cyan} to download a newer version.\n`);
+  }
+} catch (e) {
+}
 
-program.command('cat <path>')
-  .description('Output contents of remote file to STDOUT')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let CatCommand = require('../lib/Commands/CatCommand');
-    new CatCommand({offline: false}).execute(path, options);
+var config = {
+  commands: [
+    {
+      command: 'cat',
+      usage: '[options] <path>',
+      description: 'Print files to STDOUT',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/CatCommand'
+    },
+    {
+      command: 'clearcache',
+      usage: '[options]',
+      description: 'Clear the local cache',
+      options: {},
+      file: '../lib/Commands/ClearCacheCommand'
+    },
+    {
+      command: 'config',
+      usage: '[options] [key] [value]',
+      description: 'Read, write, and reset config values',
+      options: {
+        r: {
+          alias: 'reset',
+          demand: false,
+          describe: 'Reset the config option to its default value',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/ConfigCommand'
+    },
+    {
+      command: 'du',
+      usage: '[options] [path]',
+      description: 'Display the disk usage (recursively) for the specified node',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/DiskUsageCommand'
+    },
+    {
+      command: 'download',
+      usage: '[options] <src> [dest]',
+      description: 'Download remote file or folder to specified local path',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/DownloadCommand'
+    },
+    {
+      command: 'find',
+      usage: '[options] <query>',
+      description: 'Find nodes that contains a given string',
+      options: {
+        t: {
+          alias: 'time',
+          demand: false,
+          describe: 'Sort nodes by modified time',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/FindCommand'
+    },
+    {
+      command: 'info',
+      usage: '[options]',
+      description: 'Show Cloud Drive account info',
+      options: {},
+      file: '../lib/Commands/InfoCommand'
+    },
+    {
+      command: 'init',
+      usage: '[options]',
+      description: 'Initialize and authorize with Amazon Cloud Drive',
+      options: {},
+      file: '../lib/Commands/InitCommand'
+    },
+    {
+      command: 'link',
+      usage: '[options] <path>',
+      description: 'Generate a temporary, pre-authenticated download link',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/LinkCommand'
+    },
+    {
+      command: 'ls',
+      usage: '[options] [path]',
+      description: 'List all remote nodes belonging to a specified node',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        },
+        t: {
+          alias: 'time',
+          demand: false,
+          describe: 'Sort nodes by modified time',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/ListCommand'
+    },
+    {
+      command: 'pending',
+      usage: '[options]',
+      description: 'List the nodes that have a status of "PENDING"',
+      options: {
+        t: {
+          alias: 'time',
+          demand: false,
+          describe: 'Sort nodes by modified time',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/ListPendingCommand'
+    },
+    {
+      command: 'trash',
+      usage: '[options]',
+      description: 'List the nodes that have a status of "TRASH"',
+      options: {
+        t: {
+          alias: 'time',
+          demand: false,
+          describe: 'Sort nodes by modified time',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/ListTrashCommand'
+    },
+    {
+      command: 'metadata',
+      usage: '[options] [path]',
+      description: 'Retrieve metadata of a node by its path',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/MetadataCommand'
+    },
+    {
+      command: 'mkdir',
+      usage: '[options] <path>',
+      description: 'Create a remote directory path (recursively)',
+      options: {},
+      file: '../lib/Commands/MkdirCommand'
+    },
+    {
+      command: 'mv',
+      usage: '[options] <path> [new_path]',
+      description: 'Move a remote node to a new directory',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/MoveCommand'
+    },
+    {
+      command: 'quota',
+      usage: '[options]',
+      description: 'Show Cloud Drive account quota',
+      options: {},
+      file: '../lib/Commands/QuotaCommand'
+    },
+    {
+      command: 'rename',
+      usage: '[options] <path> <name>',
+      description: 'Rename a remote node',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/RenameCommand'
+    },
+    {
+      command: 'resolve',
+      usage: '[options] <id>',
+      description: 'Return the remote path of a node by its ID',
+      options: {},
+      file: '../lib/Commands/ResolveCommand'
+    },
+    {
+      command: 'restore',
+      usage: '[options] <path>',
+      description: 'Restore a remote node from the trash',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/RestoreCommand'
+    },
+    {
+      command: 'sync',
+      usage: '[options]',
+      description: 'Sync the local cache with Amazon Cloud Drive',
+      options: {},
+      file: '../lib/Commands/SyncCommand'
+    },
+    {
+      command: 'rm',
+      usage: '[options] <path>',
+      description: 'Move a remote Node to the trash',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/TrashCommand'
+    },
+    {
+      command: 'tree',
+      usage: '[options] [path]',
+      description: 'Print directory tree of the given node',
+      options: {
+        i: {
+          alias: 'id',
+          demand: false,
+          describe: 'Specify the remote node by its ID instead of path',
+          type: 'boolean'
+        },
+        a: {
+          alias: 'assets',
+          demand: false,
+          describe: 'Include ASSET nodes',
+          type: 'boolean'
+        },
+        m: {
+          alias: 'markdown',
+          demand: false,
+          describe: 'Output tree in markdown',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/TreeCommand'
+    },
+    {
+      command: 'upload',
+      usage: '[options] <src> [dest]',
+      description: 'Upload local file or folder to remote directory',
+      options: {
+        o: {
+          alias: 'overwrite',
+          demand: false,
+          describe: 'Overwrite the remote file if it already exists',
+          type: 'boolean'
+        }
+      },
+      file: '../lib/Commands/UploadCommand'
+    },
+    {
+      command: 'usage',
+      usage: '[options]',
+      description: 'Show Cloud Drive account usage',
+      options: {},
+      file: '../lib/Commands/UsageCommand'
+    }
+  ],
+  globalFlags: {
+    v: {
+      alias: 'verbose',
+      demand: false,
+      describe: 'Output verbosity: 1 for normal, 2 for more verbose, and 3 for debug',
+      type: 'count'
+    },
+    q: {
+      alias: 'quiet',
+      demand: false,
+      describe: 'Suppress all output',
+      type: 'boolean'
+    }
+  }
+};
+
+for (let i = 0; i < config.commands.length; i++) {
+  let command = config.commands[i];
+  yargs.command(command.command, command.description, (yargs, argv) => {
+    argv = yargs.usage(`\nUsage: ${command.command} ${command.usage}`)
+      .options(command.options)
+      .options(config.globalFlags)
+      .help('help')
+      .alias('h', 'help')
+      .strict()
+      .fail((message) => {
+        yargs.showHelp();
+        Command.error(message);
+        process.exit(1);
+      })
+      .argv;
+
+    Command.VERBOSE_LEVEL = argv.verbose;
+    if (argv.quiet) {
+      Command.VERBOSE_LEVEL = -1;
+    }
+
+    var Cmd = require(command.file);
+    new Cmd({offline: false}).execute(argv._.slice(1), argv);
   });
+}
 
-program.command('clearcache')
-  .description('Clear the local cache')
-  .action(function() {
-    let ClearCacheCommand = require('../lib/Commands/ClearCacheCommand');
-    new ClearCacheCommand({offline: true}).execute();
-  });
+var argv = yargs
+  .usage(`\nUsage: command [options] [arguments]`)
+  .version(function() {
+    return `v${pkgJson.version}`;
+  })
+  .alias('V', 'version')
+  .help('h')
+  .alias('h', 'help')
+  .options(config.globalFlags)
+  .epilog(`Copyright ${new Date().getFullYear()}`)
+  .strict()
+  .argv;
 
-program.command('config [key] [value]')
-  .description('Read, write, and remove config options')
-  .option('-r, --remove', 'Remove / reset the config option to its default value')
-  .action(function(key, value, options) {
-    let ConfigCommand = require('../lib/Commands/ConfigCommand');
-    new ConfigCommand({offline: true}).execute(key, value, options);
-  });
-
-program.command('download <src> [dest]')
-  .description('Download remote file or folder to specified local path')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(src, dest, options) {
-    let DownloadCommand = require('../lib/Commands/DownloadCommand');
-    new DownloadCommand({offline: false}).execute(src, dest, options);
-  });
-
-program.command('du [path]')
-  .description('Display the disk usage (recursively) for the specified node')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let DiskUsageCommand = require('../lib/Commands/DiskUsageCommand');
-    new DiskUsageCommand({offline: true}).execute(path, options);
-  });
-
-program.command('find [query]')
-  .description('Find nodes that match a name (partials acceptable)')
-  .option('-t, --time', 'Sort nodes by time modified')
-  .action(function(query, options) {
-    let FindCommand = require('../lib/Commands/FindCommand');
-    new FindCommand({offline: true}).execute(query, options);
-  });
-
-program.command('info')
-  .description('Show Cloud Drive account info')
-  .action(function(options) {
-    let InfoCommand = require('../lib/Commands/InfoCommand');
-    new InfoCommand({offline: false}).execute(options);
-  });
-
-program.command('init')
-  .description('Initialize and authorize with Amazon Cloud Drive')
-  .action(function() {
-    let InitCommand = require('../lib/Commands/InitCommand');
-    new InitCommand({offline: false}).execute();
-  });
-
-program.command('link [path]')
-  .description('Generate a temporary, pre-authenticated download link')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let LinkCommand = require('../lib/Commands/LinkCommand');
-    new LinkCommand({offline: false}).execute(path, options);
-  });
-
-program.command('ls [path]')
-  .description('List all remote nodes belonging to a specified node')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .option('-t, --time', 'Sort nodes by time modified')
-  .action(function(path, options) {
-    let ListCommand = require('../lib/Commands/ListCommand');
-    new ListCommand({offline: true}).execute(path, options);
-  });
-
-program.command('metadata [path]')
-  .description('Retrieve metadata of a node by its path')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let MetadataCommand = require('../lib/Commands/MetadataCommand');
-    new MetadataCommand({offline: true}).execute(path, options);
-  });
-
-program.command('mkdir <path>')
-  .description('Create a remote directory path (recursively)')
-  .action(function(path, options) {
-    let MkdirCommand = require('../lib/Commands/MkdirCommand');
-    new MkdirCommand({offline: false}).execute(path, options);
-  });
-
-program.command('mv <path> [new_path]')
-  .description('Move a remote node to a new directory')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, newPath, options) {
-    let MoveCommand = require('../lib/Commands/MoveCommand');
-    new MoveCommand({offline: false}).execute(path, newPath, options);
-  });
-
-program.command('pending')
-  .description('List the nodes that have a status of "PENDING"')
-  .option('-t, --time', 'Sort nodes by time modified')
-  .action(function(options) {
-    let ListPendingCommand = require('../lib/Commands/ListPendingCommand');
-    new ListPendingCommand({offline: true}).execute(options);
-  });
-
-program.command('quota')
-  .description('Show Cloud Drive account quota')
-  .action(function(options) {
-    let QuotaCommand = require('../lib/Commands/QuotaCommand');
-    new QuotaCommand({offline: false}).execute(options);
-  });
-
-program.command('rename <path> <name>')
-  .description('Rename a remote node')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, name, options) {
-    let RenameCommand = require('../lib/Commands/RenameCommand');
-    new RenameCommand({offline: false}).execute(path, name, options);
-  });
-
-program.command('resolve <id>')
-  .description('Return the remote path of a node by its ID')
-  .action(function(id) {
-    let ResolveCommand = require('../lib/Commands/ResolveCommand');
-    new ResolveCommand({offline: true}).execute(id);
-  });
-
-program.command('restore <path>')
-  .description('Restore a remote node from the trash')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let RestoreCommand = require('../lib/Commands/RestoreCommand');
-    new RestoreCommand({offline: false}).execute(path, options);
-  });
-
-program.command('rm <path>')
-  .description('Move a remote Node to the trash')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .action(function(path, options) {
-    let TrashCommand = require('../lib/Commands/TrashCommand');
-    new TrashCommand({offline: false}).execute(path, options);
-  });
-
-program.command('sync')
-  .description('Sync the local cache with Amazon Cloud Drive')
-  .action(function() {
-    let SyncCommand = require('../lib/Commands/SyncCommand');
-    new SyncCommand({offline: false}).execute();
-  });
-
-program.command('trash')
-  .description('List all nodes in the trash')
-  .option('-t, --time', 'Sort nodes by time modified')
-  .action(function(options) {
-    let ListTrashCommand = require('../lib/Commands/ListTrashCommand');
-    new ListTrashCommand({offline: true}).execute(options);
-  });
-
-program.command('tree [path]')
-  .description('Print directory tree of the given node')
-  .option('-m, --markdown', 'Output tree in Markdown')
-  .option('-i, --id', 'Specify the remote node by its ID rather than path')
-  .option('-a, --assets', 'Include ASSET nodes')
-  .action(function(path, options) {
-    let TreeCommand = require('../lib/Commands/TreeCommand');
-    new TreeCommand({offline: true}).execute(path, options);
-  });
-
-program.command('upload <src> [dest]')
-  .description('Upload local file or folder to remote directory')
-  .option('-o, --overwrite', 'Overwrite the remote file if it already exists')
-  .action(function(src, dest, options) {
-    let UploadCommand = require('../lib/Commands/UploadCommand');
-    new UploadCommand({offline: false}).execute(src, dest, options);
-  });
-
-program.command('usage')
-  .description('Show Cloud Drive account usage')
-  .action(function(options) {
-    let UsageCommand = require('../lib/Commands/UsageCommand');
-    new UsageCommand({offline: false}).execute(options);
-  });
-
-program.command('*')
-  .action(function(cmd) {
-    Command.error(`Invalid command '${cmd}'`);
-  });
-
-program.parse(process.argv);
-
-if (!process.argv.slice(2).length) {
-  program.outputHelp();
+if (!argv._[0]) {
+  yargs.showHelp();
 }

--- a/lib/Commands/CatCommand.js
+++ b/lib/Commands/CatCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class CatCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/ClearCacheCommand.js
+++ b/lib/Commands/ClearCacheCommand.js
@@ -3,7 +3,7 @@
 var Command = require('./Command');
 
 class ClearCacheCommand extends Command {
-  run() {
+  run(args, options) {
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/Command.js
+++ b/lib/Commands/Command.js
@@ -186,7 +186,7 @@ class Command {
 
     for (let key in defaultConfig) {
       var val = defaultConfig[key].default;
-      if (savedConfig.get(key)) {
+      if (savedConfig.get(key) !== undefined) {
         val = savedConfig.get(key);
       }
 
@@ -341,13 +341,16 @@ class Command {
   }
 
   static stopSpinner() {
-    clearInterval(spinner);
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
+    if (spinner) {
+      clearInterval(spinner);
+      process.stdout.clearLine();
+      process.stdout.cursorTo(0);
+    }
   }
 }
 
 Command.SORT_BY_NAME = 'name';
 Command.SORT_BY_DATE = 'date';
+Command.VERBOSE_LEVEL = 0;
 
 module.exports = Command;

--- a/lib/Commands/ConfigCommand.js
+++ b/lib/Commands/ConfigCommand.js
@@ -5,11 +5,14 @@ var Command = require('./Command'),
   colors = require('colors');
 
 class ConfigCommand extends Command {
-  run(option, value, options) {
+  run(args, options) {
+    var option = args[0],
+      value = args[1];
+
     return new Promise((resolve, reject) => {
       var data = this.config.flatten();
 
-      if (option === undefined) {
+      if (!option) {
         var keys = Object.keys(data);
         var maxSize = keys.sort((a, b) => {
           return b.length - a.length;
@@ -21,10 +24,10 @@ class ConfigCommand extends Command {
 
         return resolve();
       } else if (data[option] === undefined) {
-        return reject(`Option '${option}' not found`);
+        return reject(Error(`Option '${option}' not found`));
       }
 
-      if (value === undefined) {
+      if (!value) {
         if (options.remove) {
           this.resetConfigValue(option);
           this.saveConfig();

--- a/lib/Commands/DiskUsageCommand.js
+++ b/lib/Commands/DiskUsageCommand.js
@@ -6,7 +6,8 @@ var Command = require('./Command'),
   Utils = require('../Utils');
 
 class DiskUsageCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/DownloadCommand.js
+++ b/lib/Commands/DownloadCommand.js
@@ -6,7 +6,9 @@ var Command = require('./Command'),
   ProgressBar = require('progress');
 
 class DownloadCommand extends Command {
-  run(remotePath, localPath, options) {
+  run(args, options) {
+    var remotePath = args[0];
+    var localPath = args[1];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/FindCommand.js
+++ b/lib/Commands/FindCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class FindCommand  extends Command {
-  run(query, options) {
+  run(args, options) {
+    var query = args[0];
     var sort = Command.SORT_BY_NAME;
     if (options.time) {
       sort = Command.SORT_BY_DATE;

--- a/lib/Commands/InfoCommand.js
+++ b/lib/Commands/InfoCommand.js
@@ -3,7 +3,7 @@
 var Command = require('./Command');
 
 class InfoCommand extends Command {
-  run() {
+  run(args, options) {
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/InitCommand.js
+++ b/lib/Commands/InitCommand.js
@@ -5,7 +5,7 @@ var Command = require('./Command'),
   open = require('open');
 
 class InitCommand extends Command {
-  run() {
+  run(args, options) {
     Command.startSpinner('Initializing... ');
 
     return new Promise((resolve, reject) => {

--- a/lib/Commands/LinkCommand.js
+++ b/lib/Commands/LinkCommand.js
@@ -4,7 +4,9 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class LinkCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
+
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/ListCommand.js
+++ b/lib/Commands/ListCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class ListCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/ListPendingCommand.js
+++ b/lib/Commands/ListPendingCommand.js
@@ -4,7 +4,7 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class ListPendingCommand extends Command {
-  run(options) {
+  run(args, options) {
     var sort = Command.SORT_BY_NAME;
     if (options.time) {
       sort = Command.SORT_BY_DATE;

--- a/lib/Commands/ListTrashCommand.js
+++ b/lib/Commands/ListTrashCommand.js
@@ -4,7 +4,7 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class ListTrashCommand extends Command {
-  run(options) {
+  run(args, options) {
     var sort = Command.SORT_BY_NAME;
     if (options.time) {
       sort = Command.SORT_BY_DATE;

--- a/lib/Commands/MetadataCommand.js
+++ b/lib/Commands/MetadataCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class MetadataCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/MkdirCommand.js
+++ b/lib/Commands/MkdirCommand.js
@@ -4,7 +4,9 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class MkdirCommand extends Command {
-  run(path, options) {
+  run(args, options) {
+    var path = args[0];
+
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/MoveCommand.js
+++ b/lib/Commands/MoveCommand.js
@@ -4,7 +4,9 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class MoveCommand extends Command {
-  run(remotePath, newPath, options) {
+  run(args, options) {
+    var remotePath = args[0];
+    var newPath = args[1];
     if (!newPath) {
       newPath = '';
     }

--- a/lib/Commands/QuotaCommand.js
+++ b/lib/Commands/QuotaCommand.js
@@ -3,7 +3,7 @@
 var Command = require('./Command');
 
 class QuotaCommand extends Command {
-  run() {
+  run(args, options) {
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/RenameCommand.js
+++ b/lib/Commands/RenameCommand.js
@@ -4,7 +4,10 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class RenameCommand extends Command {
-  run(remotePath, name, options) {
+  run(args, options) {
+    var remotePath = args[0];
+    var name = args[1];
+
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/ResolveCommand.js
+++ b/lib/Commands/ResolveCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class ResolveCommand extends Command {
-  run(id) {
+  run(args, options) {
+    var id = args[0];
     if (id) {
       id = id.trim();
     }

--- a/lib/Commands/RestoreCommand.js
+++ b/lib/Commands/RestoreCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class RestoreCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/SyncCommand.js
+++ b/lib/Commands/SyncCommand.js
@@ -3,7 +3,7 @@
 var Command = require('./Command');
 
 class SyncCommand extends Command {
-  run(options) {
+  run(args, options) {
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/TrashCommand.js
+++ b/lib/Commands/TrashCommand.js
@@ -4,7 +4,8 @@ var Command = require('./Command'),
   Node = require('../Node');
 
 class TrashCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/TreeCommand.js
+++ b/lib/Commands/TreeCommand.js
@@ -6,7 +6,8 @@ var Command = require('./Command'),
   colors = require('colors');
 
 class TreeCommand extends Command {
-  run(remotePath, options) {
+  run(args, options) {
+    var remotePath = args[0];
     var searchFunction = Node.loadByPath;
     var notFound = `No node exists at path '${remotePath}'`;
     if (options.id) {

--- a/lib/Commands/UploadCommand.js
+++ b/lib/Commands/UploadCommand.js
@@ -7,7 +7,10 @@ var fs = require('fs'),
   ProgressBar = require('progress');
 
 class UploadCommand extends Command {
-  run(localPath, remotePath, options) {
+  run(args, options) {
+    var localPath = args[0];
+    var remotePath = args[1];
+
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/lib/Commands/UsageCommand.js
+++ b/lib/Commands/UsageCommand.js
@@ -3,7 +3,7 @@
 var Command = require('./Command');
 
 class UsageCommand extends Command {
-  run() {
+  run(args, options) {
     return new Promise((resolve, reject) => {
       this.initialize((err, data) => {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "async": "^1.4.2",
     "colors": "^1.1.2",
-    "commander": "^2.8.1",
     "elegant-spinner": "^1.0.0",
     "inquirer": "^0.10.0",
     "knex": "^0.8.6",
@@ -32,7 +31,9 @@
     "open": "0.0.5",
     "progress": "^1.1.8",
     "request": "^2.61.0",
-    "sqlite3": "^3.1.0"
+    "semver": "^5.1.0",
+    "sqlite3": "^3.1.0",
+    "yargs": "^3.31.0"
   },
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
Changed out the CLI framework / parser from `commander` to `yargs` due to flexibility, ability for global flags, etc.
