### PR TITLE
fix issue on windows with drive letter mismatch ex. during upload we …

### DIFF
--- a/lib/Commands/UploadCommand.js
+++ b/lib/Commands/UploadCommand.js
@@ -59,14 +59,14 @@ class UploadCommand extends Command {
             onFileProgress: (localPath, chunk) => {
               if (bar) {
                 bytesDispatched += chunk.length;
-                bytesUploaded += bytesDispatched;
+                bytesUploaded += chunk.length;
 
                 let message = `Uploading '${localPath}'`,
                   timeDiff = Date.now() - lastRun;
 
                 if (timeDiff >= this.config.get('cli.progressInterval') || bytesUploaded >= localFilesize) {
                   lastRun = Date.now();
-                  bar.tick(chunk.length, {
+                  bar.tick(bytesDispatched, {
                     speed: `${Utils.convertFileSize(Math.round(bytesDispatched * 1000 / timeDiff), 2)}/s`
                   });
                   message += `\n${bar.lastDraw}`;

--- a/lib/Commands/UploadCommand.js
+++ b/lib/Commands/UploadCommand.js
@@ -66,12 +66,12 @@ class UploadCommand extends Command {
 
                 if (timeDiff >= this.config.get('cli.progressInterval') || bytesUploaded >= localFilesize) {
                   lastRun = Date.now();
-                  bytesDispatched = 0;
                   bar.tick(chunk.length, {
                     speed: `${Utils.convertFileSize(Math.round(bytesDispatched * 1000 / timeDiff), 2)}/s`
                   });
                   message += `\n${bar.lastDraw}`;
                   logUpdate(message);
+                  bytesDispatched = 0;
                 }
               }
             },
@@ -145,6 +145,7 @@ class UploadCommand extends Command {
               callback();
             });
           }
+
 
           Node.uploadFile(localPath, remotePath, opts, (err, data) => {
             if (err) {

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,7 +1,8 @@
 'use strict';
 
 let fs = require('fs'),
-  crypto = require('crypto');
+    crypto = require('crypto'),
+    path = require('path');
 
 class Utils {
   static convertFileSize(bytes, decimals = 2) {
@@ -85,12 +86,12 @@ class Utils {
     return path;
   }
 
-  static getPathArray(path) {
+  static getPathArray(remotePath) {
     let retval = [];
-    path = path.split('/');
-    for (let i = 0; i < path.length; i++) {
-      if (path[i]) {
-        retval.push(path[i]);
+    remotePath = remotePath.split('/');
+    for (let i = 0; i < remotePath.length; i++) {
+      if (remotePath[i]) {
+        retval.push(path.basename(remotePath[i]));
       }
     }
 


### PR DESCRIPTION
…create "D:\Temp" directory but test if exists "Temp" directory. That leads to 409 errors
